### PR TITLE
Add --region / -r CLI parameter; update README.md to explain general usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,5 +32,10 @@ Build with `mvn assembly:assembly`
 ./aws-api-export.sh --api API_ID --format json --output FILENAME.json
 ```
 
+### Describe all CLI parameters
+```sh
+./aws-api-exporter.sh
+```
+
 For Windows environments replace `./aws-api-export.sh` with `./aws-api-export.cmd` in the examples.
 

--- a/src/main/java/com/bytecodestudio/apigexporter/APIGExporterMain.java
+++ b/src/main/java/com/bytecodestudio/apigexporter/APIGExporterMain.java
@@ -19,6 +19,9 @@ public class APIGExporterMain {
     @com.beust.jcommander.Parameter(names = {"--api", "-a"}, description = "API ID to export")
     private String apiId;
 
+    @com.beust.jcommander.Parameter(names = {"--region", "-r"}, description = "AWS Region")
+    private String region = getRegionFromEnvironmentVariable();
+
     @com.beust.jcommander.Parameter(names = {"--format", "-f"}, description = "Swagger file format: yaml or json")
     private String format = "yaml";
 
@@ -50,7 +53,6 @@ public class APIGExporterMain {
         }
 
         AWSCredentialsProvider provider = getEnvironmentVariableCredentialsProvider();
-        String region = getRegionFromEnvironmentVariable();
         if (provider == null || region == null) {
             AwsConfig config = new AwsConfig(profile);
             try {


### PR DESCRIPTION
Because AWS API Gateway is not available in many regions, it's useful to have a CLI parameter for --region.  

Also, the CLI documentation didn't mention how to discover the usage.
